### PR TITLE
fix use default_prefix

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -1026,11 +1026,6 @@ class HttpClient(RestClientBase):
         :returns: returns a rest request
 
         """
-        if self.default_prefix == path and path[-1] != '/':
-            path = path + '/'
-        else:
-            pass
-
         return super(HttpClient, self)._rest_request(path=path, method=method,
                                                      args=args, body=body,
                                                      headers=headers,


### PR DESCRIPTION
if you need to use default_prefix='/redfish/v1'
instead of default_prefix='/redfish/v1/' this block of code prevents it from doing so.